### PR TITLE
move standards to dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,13 +24,13 @@
         }
     ],
     "require": {
-        "php": ">=5.5",
-        "graze/standards": "^1.0"
+        "php": "^5.5|^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4||^5",
         "squizlabs/php_codesniffer": "^2.3,<2.8.1",
-        "johnkary/phpunit-speedtrap": "^1.0"
+        "johnkary/phpunit-speedtrap": "^1.0",
+        "graze/standards": "^1.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
We only use standards in development, should not be a production requirement.