### PR TITLE
Accept int's as string as ports

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -219,7 +219,7 @@ class Client
         $setOption = function ($name, $type = null) use ($options) {
             if (isset($options[$name])) {
                 if (!is_null($type) && (gettype($options[$name]) != $type)) {
-                    throw new ConfigurationException($this, sprintf(
+                    throw new ConfigurationException($this->instanceId, sprintf(
                         "Option: %s is expected to be: '%s', was: '%s'",
                         $name,
                         $type,
@@ -231,7 +231,7 @@ class Client
         };
 
         $setOption('host', 'string');
-        $setOption('port', 'integer');
+        $setOption('port');
         $setOption('namespace', 'string');
         $setOption('timeout');
         $setOption('onError', 'string');

--- a/src/Client.php
+++ b/src/Client.php
@@ -238,8 +238,9 @@ class Client
         $setOption('dataDog', 'boolean');
         $setOption('tags', 'array');
 
+        $this->port = (int) $this->port;
         if (!$this->port || !is_numeric($this->port) || $this->port > 65535) {
-            throw new ConfigurationException($this->instanceId, 'Option: Port is out of range');
+            throw new ConfigurationException($this->instanceId, 'Option: Port is invalid or is out of range');
         }
 
         if (!in_array(

--- a/tests/unit/ConfigurationTest.php
+++ b/tests/unit/ConfigurationTest.php
@@ -39,7 +39,7 @@ class ConfigurationTest extends TestCase
 
     /**
      * @expectedException \Graze\DogStatsD\Exception\ConfigurationException
-     * @expectedExceptionMessage Option: Port is out of range
+     * @expectedExceptionMessage Option: Port is invalid or is out of range
      */
     public function testLargePortWillThrowAnException()
     {
@@ -50,7 +50,7 @@ class ConfigurationTest extends TestCase
 
     /**
      * @expectedException \Graze\DogStatsD\Exception\ConfigurationException
-     * @expectedExceptionMessage Option: port is expected to be: 'integer', was: 'string'
+     * @expectedExceptionMessage Option: Port is invalid or is out of range
      */
     public function testStringPortWillThrowAnException()
     {
@@ -59,9 +59,17 @@ class ConfigurationTest extends TestCase
         ]);
     }
 
+    public function testValidStringPort()
+    {
+        $this->client->configure([
+            'port' => '1234',
+        ]);
+        $this->assertEquals(1234, $this->client->getPort());
+    }
+
     public function testDefaultPort()
     {
-        $this->assertEquals($this->client->getPort(), 8125);
+        $this->assertEquals(8125, $this->client->getPort());
     }
 
     public function testValidPort()
@@ -69,7 +77,7 @@ class ConfigurationTest extends TestCase
         $this->client->configure([
             'port' => 1234,
         ]);
-        $this->assertEquals($this->client->getPort(), 1234);
+        $this->assertEquals(1234, $this->client->getPort());
     }
 
     /**


### PR DESCRIPTION
- Handle string ports `'1234'` to support environment variable inputs
- Also raising a `ConfigurationException` for invalid type