### PR TITLE
Get the stream

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -602,4 +602,12 @@ class Client
 
         return $this;
     }
+
+    /**
+     * @return StreamWriter The stream
+     */
+    public function getStream()
+    {
+        return $this->stream;
+    }
 }


### PR DESCRIPTION
Close #27. 

Add a public method to get the StreamWriter object from the Client. This enables closing the socket:

```php
$statsd = new \Graze\DogStatsD\Client();
$statsd->configure(
    [
        'host' => '127.0.0.1',
        'port' => 8125,
        'namespace' => 'some.namespace',
    ]
);

$statsd->gauge('someMetric', 1);

$stream = $statsd->getStream();
$stream->__destruct();

unset($statsd);
``` 