### PR TITLE
remove circluar reference between client and stream

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -176,11 +176,11 @@ class Client
     }
 
     /**
-     * @param string $name
+     * @param string $name Instance name
      *
      * @return bool true if an instance has been found and removed
      */
-    public static function deleteInstance($name)
+    public static function deleteInstance($name = 'default')
     {
         if (isset(static::$instances[$name])) {
             unset(static::$instances[$name]);

--- a/src/Client.php
+++ b/src/Client.php
@@ -161,13 +161,6 @@ class Client
     protected $tags = [];
 
     /**
-     * List of tags processors to apply to every metric being sent out
-     *
-     * @var callable[]
-     */
-    protected $tagProcessors = [];
-
-    /**
      * Singleton Reference
      *
      * @param  string $name Instance name
@@ -231,7 +224,6 @@ class Client
      *                       :onError <enum[error,exception,ignore]> - What we should do on error
      *                       :dataDog <bool> - Use DataDog's version of statsd (Default: true)
      *                       :tags <array> - List of tags to add to each message
-     *                       :tagProcessors <array> - List of tags processors to use `function (array $tags): array`
      *
      * @return Client This instance
      * @throws ConfigurationException If port is invalid
@@ -260,15 +252,6 @@ class Client
         $setOption('dataDog', 'boolean');
         $setOption('tags', 'array');
 
-        if (isset($options['tagProcessors']) && is_array($options['tagProcessors'])) {
-            foreach ($options['tagProcessors'] as $tagProcessor) {
-                if (!is_callable($tagProcessor)) {
-                    throw new ConfigurationException($this->instanceId, 'supplied tag processor is not a callable');
-                }
-                $this->addTagProcessor($tagProcessor);
-            }
-        }
-
         $this->port = (int) $this->port;
         if (!$this->port || !is_numeric($this->port) || $this->port > 65535) {
             throw new ConfigurationException($this->instanceId, 'Option: Port is invalid or is out of range');
@@ -284,17 +267,6 @@ class Client
             );
         }
 
-        return $this;
-    }
-
-    /**
-     * @param callable $tagsProcessor function (array $tags): array
-     *
-     * @return Client
-     */
-    public function addTagProcessor(callable $tagsProcessor)
-    {
-        $this->tagProcessors[] = $tagsProcessor;
         return $this;
     }
 
@@ -621,7 +593,7 @@ class Client
     {
         $messages = [];
         $prefix = $this->namespace ? $this->namespace . '.' : '';
-        $formattedTags = $this->formatTags($this->processTags(array_merge($this->tags, $tags)));
+        $formattedTags = $this->formatTags(array_merge($this->tags, $tags));
         foreach ($data as $key => $value) {
             $messages[] = $prefix . $key . ':' . $value . $formattedTags;
         }
@@ -649,20 +621,5 @@ class Client
         $this->written = $this->stream->write($this->message);
 
         return $this;
-    }
-
-    /**
-     * Process a set of tags with some user defined processes to add custom runtime data
-     *
-     * @param array $tags
-     *
-     * @return array|mixed
-     */
-    private function processTags(array $tags)
-    {
-        foreach ($this->tagProcessors as $tagProcessor) {
-            $tags = call_user_func($tagProcessor, $tags);
-        }
-        return $tags;
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -637,11 +637,13 @@ class Client
     protected function sendMessages(array $messages)
     {
         if (is_null($this->stream)) {
-            $this->stream = new StreamWriter($this->instanceId,
+            $this->stream = new StreamWriter(
+                $this->instanceId,
                 $this->host,
                 $this->port,
                 $this->onError,
-                $this->timeout);
+                $this->timeout
+            );
         }
         $this->message = implode("\n", $messages);
         $this->written = $this->stream->write($this->message);

--- a/src/Client.php
+++ b/src/Client.php
@@ -183,6 +183,20 @@ class Client
     }
 
     /**
+     * @param string $name
+     *
+     * @return bool true if an instance has been found and removed
+     */
+    public static function deleteInstance($name)
+    {
+        if (isset(static::$instances[$name])) {
+            unset(static::$instances[$name]);
+            return true;
+        }
+        return false;
+    }
+
+    /**
      * Create a new instance
      *
      * @param string|null $instanceId
@@ -623,7 +637,11 @@ class Client
     protected function sendMessages(array $messages)
     {
         if (is_null($this->stream)) {
-            $this->stream = new StreamWriter($this->instanceId, $this->host, $this->port, $this->onError, $this->timeout);
+            $this->stream = new StreamWriter($this->instanceId,
+                $this->host,
+                $this->port,
+                $this->onError,
+                $this->timeout);
         }
         $this->message = implode("\n", $messages);
         $this->written = $this->stream->write($this->message);

--- a/src/Client.php
+++ b/src/Client.php
@@ -15,8 +15,8 @@ namespace Graze\DogStatsD;
 
 use Graze\DogStatsD\Exception\ConfigurationException;
 use Graze\DogStatsD\Exception\ConnectionException;
-use Graze\DogStatsD\Stream\WriterInterface;
 use Graze\DogStatsD\Stream\StreamWriter;
+use Graze\DogStatsD\Stream\WriterInterface;
 
 /**
  * StatsD Client Class - Modified to support DataDogs statsd server
@@ -161,6 +161,13 @@ class Client
     protected $tags = [];
 
     /**
+     * List of tags processors to apply to every metric being sent out
+     *
+     * @var callable[]
+     */
+    protected $tagProcessors = [];
+
+    /**
      * Singleton Reference
      *
      * @param  string $name Instance name
@@ -210,6 +217,7 @@ class Client
      *                       :onError <enum[error,exception,ignore]> - What we should do on error
      *                       :dataDog <bool> - Use DataDog's version of statsd (Default: true)
      *                       :tags <array> - List of tags to add to each message
+     *                       :tagProcessors <array> - List of tags processors to use `function (array $tags): array`
      *
      * @return Client This instance
      * @throws ConfigurationException If port is invalid
@@ -238,6 +246,15 @@ class Client
         $setOption('dataDog', 'boolean');
         $setOption('tags', 'array');
 
+        if (isset($options['tagProcessors']) && is_array($options['tagProcessors'])) {
+            foreach ($options['tagProcessors'] as $tagProcessor) {
+                if (!is_callable($tagProcessor)) {
+                    throw new ConfigurationException($this->instanceId, 'supplied tag processor is not a callable');
+                }
+                $this->addTagProcessor($tagProcessor);
+            }
+        }
+
         $this->port = (int) $this->port;
         if (!$this->port || !is_numeric($this->port) || $this->port > 65535) {
             throw new ConfigurationException($this->instanceId, 'Option: Port is invalid or is out of range');
@@ -253,6 +270,17 @@ class Client
             );
         }
 
+        return $this;
+    }
+
+    /**
+     * @param callable $tagsProcessor function (array $tags): array
+     *
+     * @return Client
+     */
+    public function addTagProcessor(callable $tagsProcessor)
+    {
+        $this->tagProcessors[] = $tagsProcessor;
         return $this;
     }
 
@@ -579,7 +607,7 @@ class Client
     {
         $messages = [];
         $prefix = $this->namespace ? $this->namespace . '.' : '';
-        $formattedTags = $this->formatTags(array_merge($this->tags, $tags));
+        $formattedTags = $this->formatTags($this->processTags(array_merge($this->tags, $tags)));
         foreach ($data as $key => $value) {
             $messages[] = $prefix . $key . ':' . $value . $formattedTags;
         }
@@ -595,11 +623,26 @@ class Client
     protected function sendMessages(array $messages)
     {
         if (is_null($this->stream)) {
-            $this->stream = new StreamWriter($this, $this->host, $this->port, $this->onError, $this->timeout);
+            $this->stream = new StreamWriter($this->instanceId, $this->host, $this->port, $this->onError, $this->timeout);
         }
         $this->message = implode("\n", $messages);
         $this->written = $this->stream->write($this->message);
 
         return $this;
+    }
+
+    /**
+     * Process a set of tags with some user defined processes to add custom runtime data
+     *
+     * @param array $tags
+     *
+     * @return array|mixed
+     */
+    private function processTags(array $tags)
+    {
+        foreach ($this->tagProcessors as $tagProcessor) {
+            $tags = call_user_func($tagProcessor, $tags);
+        }
+        return $tags;
     }
 }

--- a/tests/unit/ClientTest.php
+++ b/tests/unit/ClientTest.php
@@ -61,4 +61,31 @@ class ClientTest extends TestCase
         $this->assertNull($client);
         $this->assertFalse(is_resource($socket));
     }
+
+    public function testRemovalOfStaticInstance()
+    {
+        $client = Client::instance('first');
+        $client->configure([]);
+        $client->increment('test', 1);
+
+        // get the stream
+        $reflector = new ReflectionProperty(Client::class, 'stream');
+        $reflector->setAccessible(true);
+        $stream = $reflector->getValue($client);
+
+        // get the socket
+        $reflector = new ReflectionProperty(StreamWriter::class, 'socket');
+        $reflector->setAccessible(true);
+        $socket = $reflector->getValue($stream);
+
+        $stream = null;
+        $this->assertTrue(is_resource($socket));
+        $client = null;
+
+        $this->assertNull($client);
+        $this->assertTrue(is_resource($socket));
+
+        Client::deleteInstance('first');
+        $this->assertFalse(is_resource($socket));
+    }
 }

--- a/tests/unit/ClientTest.php
+++ b/tests/unit/ClientTest.php
@@ -85,7 +85,12 @@ class ClientTest extends TestCase
         $this->assertNull($client);
         $this->assertTrue(is_resource($socket));
 
-        Client::deleteInstance('first');
+        $this->assertTrue(Client::deleteInstance('first'));
         $this->assertFalse(is_resource($socket));
+    }
+
+    public function testDeleteInstanceOfNonExistantInstanceReturnsFalse()
+    {
+        $this->assertFalse(Client::deleteInstance('nope'));
     }
 }

--- a/tests/unit/ClientTest.php
+++ b/tests/unit/ClientTest.php
@@ -93,4 +93,13 @@ class ClientTest extends TestCase
     {
         $this->assertFalse(Client::deleteInstance('nope'));
     }
+
+    public function testDefaultInstances()
+    {
+        $client1 = Client::instance();
+        $this->assertTrue(Client::deleteInstance());
+        $this->assertFalse(Client::deleteInstance());
+        $client2 = Client::instance();
+        $this->assertNotSame($client1, $client2);
+    }
 }

--- a/tests/unit/ClientTest.php
+++ b/tests/unit/ClientTest.php
@@ -14,7 +14,9 @@
 namespace Graze\DogStatsD\Test\Unit;
 
 use Graze\DogStatsD\Client;
+use Graze\DogStatsD\Stream\StreamWriter;
 use Graze\DogStatsD\Test\TestCase;
+use ReflectionProperty;
 
 class ClientTest extends TestCase
 {
@@ -41,8 +43,22 @@ class ClientTest extends TestCase
         $client = new Client();
         $client->configure([]);
         $client->increment('test', 1);
+
+        // get the stream
+        $reflector = new ReflectionProperty(Client::class, 'stream');
+        $reflector->setAccessible(true);
+        $stream = $reflector->getValue($client);
+
+        // get the socket
+        $reflector = new ReflectionProperty(StreamWriter::class, 'socket');
+        $reflector->setAccessible(true);
+        $socket = $reflector->getValue($stream);
+
+        $stream = null;
+        $this->assertTrue(is_resource($socket));
         $client = null;
 
         $this->assertNull($client);
+        $this->assertFalse(is_resource($socket));
     }
 }

--- a/tests/unit/Stream/StreamWriterTest.php
+++ b/tests/unit/Stream/StreamWriterTest.php
@@ -25,6 +25,23 @@ class StreamWriterTest extends TestCase
         $this->assertNull($writer);
     }
 
+    public function testDestructionWillCloseTheSocket()
+    {
+        $writer = new StreamWriter();
+        $writer->write('test');
+
+        // close the socket
+        $reflector = new ReflectionProperty(StreamWriter::class, 'socket');
+        $reflector->setAccessible(true);
+        $socket = $reflector->getValue($writer);
+
+        $this->assertTrue(is_resource($socket));
+        $writer = null;
+
+        $this->assertNull($writer);
+        $this->assertFalse(is_resource($socket));
+    }
+
     public function testSendFailureWillReconnect()
     {
         $writer = new StreamWriter();


### PR DESCRIPTION
Fixes #27 

- Removes a circular reference to destroying the client, destroys the stream, closes the socket.
- Adds a `Client::deleteInstance($name)` method to remove the static reference to an instance too.
