### PR TITLE
Add a .gitattributes file to exclude tests and build config files from the git archive file.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/Makefile export-ignore
+/phpcs.xml export-ignore
+/phpunit.xml.dist export-ignore
+/tests export-ignore


### PR DESCRIPTION
This will prevent Composer from copying the tests and build config files into the `vendor` directory when requiring the library using `composer require graze/dog-statsd --prefer-dist`.