### PR TITLE
support dd env vars

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -238,7 +238,7 @@ class Client
      */
     public function configure(array $options = [])
     {
-        $setOption = function ($name, $type = null) use ($options) {
+        $setOption = function ($name, $type = null, $default = false) use ($options) {
             if (isset($options[$name])) {
                 if (!is_null($type) && (gettype($options[$name]) != $type)) {
                     throw new ConfigurationException($this->instanceId, sprintf(
@@ -249,16 +249,22 @@ class Client
                     ));
                 }
                 $this->{$name} = $options[$name];
+            } elseif ($default) {
+                $this->{$name} = $default;
             }
         };
 
-        $setOption('host', 'string');
-        $setOption('port');
+        $setOption('host', 'string', getenv('DD_AGENT_HOST'));
+        $setOption('port', null, getenv('DD_DOGSTATSD_PORT'));
         $setOption('namespace', 'string');
         $setOption('timeout');
         $setOption('onError', 'string');
         $setOption('dataDog', 'boolean');
         $setOption('tags', 'array');
+
+        if (getenv('DD_ENTITY_ID')) {
+            $this->tags['dd.internal.entity_id'] = getenv('DD_ENTITY_ID');
+        }
 
         if (isset($options['tagProcessors']) && is_array($options['tagProcessors'])) {
             foreach ($options['tagProcessors'] as $tagProcessor) {

--- a/tests/unit/EnvConfigurationTest.php
+++ b/tests/unit/EnvConfigurationTest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * This file is part of graze/dog-statsd
+ *
+ * Copyright (c) 2016 Nature Delivered Ltd. <https://www.graze.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license https://github.com/graze/dog-statsd/blob/master/LICENSE.md
+ * @link    https://github.com/graze/dog-statsd
+ */
+
+namespace Graze\DogStatsD\Test\Unit;
+
+use Graze\DogStatsD\Test\TestCase;
+
+class EnvConfigurationTest extends TestCase
+{
+    public function tearDown()
+    {
+        putenv('DD_AGENT_HOST=');
+        putenv('DD_DOGSTATSD_PORT=');
+        putenv('DD_ENTITY_ID=');
+    }
+
+    public function testHost()
+    {
+        putenv('DD_AGENT_HOST=127.0.0.1');
+        $this->client->configure();
+
+        $this->assertEquals('127.0.0.1', $this->client->getHost());
+    }
+
+    public function testPort()
+    {
+        putenv('DD_DOGSTATSD_PORT=12434');
+        $this->client->configure();
+
+        $this->assertEquals(12434, $this->client->getPort());
+    }
+
+    /**
+     * @expectedException \Graze\DogStatsD\Exception\ConfigurationException
+     * @expectedExceptionMessage Option: Port is invalid or is out of range
+     */
+    public function testLargePortWillThrowAnException()
+    {
+        putenv('DD_DOGSTATSD_PORT=65536');
+        $this->client->configure();
+    }
+
+    /**
+     * @expectedException \Graze\DogStatsD\Exception\ConfigurationException
+     * @expectedExceptionMessage Option: Port is invalid or is out of range
+     */
+    public function testStringPortWillThrowAnException()
+    {
+        putenv('DD_DOGSTATSD_PORT=not-integer');
+        $this->client->configure();
+    }
+
+    public function testTags()
+    {
+        putenv('DD_ENTITY_ID=f87dsf7dsf9s7d9f8');
+        $this->client->configure();
+
+        $this->client->gauge('test_metric', 456);
+        $this->assertEquals('test_metric:456|g|#dd.internal.entity_id:f87dsf7dsf9s7d9f8', $this->client->getLastMessage());
+    }
+
+    public function testTagsAppended()
+    {
+        putenv('DD_ENTITY_ID=f87dsf7dsf9s7d9f8');
+        $this->client->configure([
+            'tags' => ['key' => 'value'],
+        ]);
+
+        $this->client->gauge('test_metric', 456);
+        $this->assertEquals('test_metric:456|g|#key:value,dd.internal.entity_id:f87dsf7dsf9s7d9f8', $this->client->getLastMessage());
+    }
+}


### PR DESCRIPTION
Closes #31 

Adds support for the following Environment variables:

- `DD_AGENT_HOST` used to provide the Agent hostname.
- `DD_DOGSTATSD_PORT` used to provide the DogStatsD port.
- `DD_ENTITY_ID` used to provide an identifier to the Client.

Precedence:

```
$config > ENV > defaults
```