### PR TITLE
Include default tags for events and service checks

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -564,7 +564,7 @@ class Client
             }
         }
 
-        $value .= $this->formatTags($tags);
+        $value .= $this->formatTags($this->processTags(array_merge($this->tags, $tags)));
 
         return $this->sendMessages([
             sprintf('%s:%s', $metric, $value),
@@ -604,7 +604,7 @@ class Client
         };
 
         $applyMetadata($metadata, $this->serviceCheckMetaData);
-        $value .= $this->formatTags($tags);
+        $value .= $this->formatTags($this->processTags(array_merge($this->tags, $tags)));
         $applyMetadata($metadata, $this->serviceCheckMessage);
 
         return $this->sendMessages([

--- a/tests/unit/TagsTest.php
+++ b/tests/unit/TagsTest.php
@@ -13,6 +13,7 @@
 
 namespace Graze\DogStatsD\Test\Unit;
 
+use Graze\DogStatsD\Client;
 use Graze\DogStatsD\Test\TestCase;
 
 class TagsTest extends TestCase
@@ -51,5 +52,25 @@ class TagsTest extends TestCase
         ]);
         $this->client->increment('test_metric', 1, 1, ['tag2']);
         $this->assertEquals('test_metric:1|c|#tag1,tag2', $this->client->getLastMessage());
+    }
+
+    public function testDefaultTagsGetAddedToEventRequest()
+    {
+        $this->client->configure([
+            'tags' => ['tag1'],
+        ]);
+
+        $this->client->event('some_title', 'textAndThings', [], ['tag2']);
+        $this->assertEquals('_e{10,13}:some_title|textAndThings|#tag1,tag2', $this->client->getLastMessage());
+    }
+
+    public function testDefaultTagsGetAddedToServiceCheckRequest()
+    {
+        $this->client->configure([
+            'tags' => ['tag1'],
+        ]);
+
+        $this->client->serviceCheck('service.api', Client::STATUS_OK, [], ['tag2']);
+        $this->assertEquals('_sc|service.api|0|#tag1,tag2', $this->client->getLastMessage());
     }
 }


### PR DESCRIPTION
Currently, the default tags are only sent for metrics, which can be surprising and unexpected.  (It took longer than I'd like to admit to figure this out).

In my case, I'm trying to configure a default set of tags to annotate everything I send to Datadog with information about the environment where my code is running.  I'd like these default tags applied to everything - not just the metrics.

This change will ensure all default tags are sent for events and service checks, as well as running any tag processors that are defined.